### PR TITLE
Fix Init

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@
 INTERVAL=${SCRIPT_INTERVAL:-300}
 
 while true; do
-    if ps aux | grep "rsoul.py" > /dev/null; then
+    if pgrep "python" > /dev/null; then
         echo "Soularr is already running. Exiting..."
     else
         #Pass in the arguments given to the bash script over to the Python script


### PR DESCRIPTION
using `ps aux` seems to indicate that rsoul is running- even when it is not. 
```
I have no name!@d02ddd268db0:/app$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
1000           1  0.0  0.0   4496  3432 ?        Ss   10:11   0:00 bash run.sh
1000          29  0.0  0.0   4892  4060 pts/0    Ss   10:12   0:00 /bin/bash
1000         134  0.0  0.0   4760  3996 pts/1    Ss+  10:21   0:00 /bin/bash
1000         172  0.0  0.0   3016  1968 ?        S    10:24   0:00 sleep 30
1000         173  0.0  0.0   6788  4032 pts/0    R+   10:24   0:00 ps aux

I have no name!@d02ddd268db0:/app$ ps -o pid,command | grep python
    175 grep python
I have no name!@d02ddd268db0:/app$ ps -o pid,command | grep rsoul
    177 grep rsoul
```
Moving to pgrep seems to resolve this, as it correctly returns the PID of the running script, or none if there is no PID.

(below example is not running)
```
I have no name!@d02ddd268db0:/app$ pgrep "python"
I have no name!@d02ddd268db0:/app$ 
```
(this is with the script running)
```
I have no name!@d02ddd268db0:/app$ pgrep "python"
199
I have no name!@d02ddd268db0:/app$ 
```

This pull request is to change to using prep to detect if the python script is started or not. 